### PR TITLE
fix broken link

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
   export DEBIAN_FRONTEND=noninteractive
   apt-get -y --allow-unauthenticated update
 	apt-get -y install curl
-  wget   http://old-releases.ubuntu.com/ubuntu/pool/universe/h/hcxtools/hcxtools_6.0.2-1_amd64.deb
+  wget http://old-releases.ubuntu.com/ubuntu/pool/universe/h/hcxtools/hcxtools_6.0.2-1_amd64.deb
   apt-get -y install ./hcxtools_6.0.2-1_amd64.deb
 	curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 	apt-get -y install nodejs

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
   export DEBIAN_FRONTEND=noninteractive
   apt-get -y --allow-unauthenticated update
 	apt-get -y install curl
-  wget http://archive.ubuntu.com/ubuntu/pool/universe/h/hcxtools/hcxtools_6.0.2-1_amd64.deb
+  wget   http://old-releases.ubuntu.com/ubuntu/pool/universe/h/hcxtools/hcxtools_6.0.2-1_amd64.deb
   apt-get -y install ./hcxtools_6.0.2-1_amd64.deb
 	curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 	apt-get -y install nodejs


### PR DESCRIPTION
```http://archive.ubuntu.com/ubuntu/pool/universe/h/hcxtools/hcxtools_6.0.2-1_amd64.deb``` no longer exists. I was getting weird errors using the most recent version. 